### PR TITLE
Add ConfigResource for PHPUnit configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+0.1
+---
+
+* Add extension

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ MIT License - see [LICENSE](LICENSE) file for details.
 
 ---
 
-*Built with the MatesOfMate community*
+*"Because every Mate needs Mates"*

--- a/config/config.php
+++ b/config/config.php
@@ -10,6 +10,7 @@
  */
 
 use MatesOfMate\Common\Process\ProcessExecutor;
+use MatesOfMate\PHPUnitExtension\Capability\ConfigResource;
 use MatesOfMate\PHPUnitExtension\Capability\ListTestsTool;
 use MatesOfMate\PHPUnitExtension\Capability\RunFileTool;
 use MatesOfMate\PHPUnitExtension\Capability\RunMethodTool;
@@ -49,4 +50,7 @@ return static function (ContainerConfigurator $container): void {
     $services->set(RunFileTool::class);
     $services->set(RunMethodTool::class);
     $services->set(ListTestsTool::class);
+
+    // Resources - automatically discovered by #[McpResource] attribute
+    $services->set(ConfigResource::class);
 };

--- a/src/Capability/ConfigResource.php
+++ b/src/Capability/ConfigResource.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the MatesOfMate Organisation.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MatesOfMate\PHPUnitExtension\Capability;
+
+use MatesOfMate\PHPUnitExtension\Config\ConfigurationDetector;
+use Mcp\Capability\Attribute\McpResource;
+
+/**
+ * Provides PHPUnit configuration information as an MCP resource.
+ *
+ * @author Johannes Wachter <johannes@sulu.io>
+ */
+class ConfigResource
+{
+    public function __construct(
+        private readonly ConfigurationDetector $configDetector,
+    ) {
+    }
+
+    /**
+     * @return array{uri: string, mimeType: string, text: string}
+     */
+    #[McpResource(
+        uri: 'phpunit://config',
+        name: 'phpunit-configuration',
+        description: 'PHPUnit project configuration details in TOON format. Provides project root, config file path, test directories, bootstrap file, and full config content. Use for: understanding project setup, checking test configuration, locating test directories, troubleshooting configuration issues.',
+        mimeType: 'text/plain',
+    )]
+    public function getConfiguration(): array
+    {
+        $projectRoot = getcwd();
+        if (false === $projectRoot) {
+            throw new \RuntimeException('Unable to determine current working directory');
+        }
+
+        $configPath = $this->configDetector->detect($projectRoot);
+
+        $data = [
+            'project_root' => $projectRoot,
+            'config_file' => $configPath,
+            'config_exists' => null !== $configPath,
+        ];
+
+        if (null !== $configPath) {
+            $data['test_directories'] = $this->configDetector->getTestDirectories();
+            $data['bootstrap_file'] = $this->extractBootstrapFile($configPath);
+            $data['config_content'] = file_exists($configPath) ? file_get_contents($configPath) : null;
+        }
+
+        return [
+            'uri' => 'phpunit://config',
+            'mimeType' => 'text/plain',
+            'text' => toon($data),
+        ];
+    }
+
+    private function extractBootstrapFile(string $configPath): ?string
+    {
+        $xml = @simplexml_load_file($configPath);
+        if (false === $xml) {
+            return null;
+        }
+
+        $bootstrap = $xml->attributes()['bootstrap'] ?? null;
+
+        return null !== $bootstrap ? (string) $bootstrap : null;
+    }
+}

--- a/tests/Unit/Capability/ConfigResourceTest.php
+++ b/tests/Unit/Capability/ConfigResourceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/*
+ * This file is part of the MatesOfMate Organisation.
+ *
+ * (c) Johannes Wachter <johannes@sulu.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MatesOfMate\PHPUnitExtension\Tests\Unit\Capability;
+
+use MatesOfMate\PHPUnitExtension\Capability\ConfigResource;
+use MatesOfMate\PHPUnitExtension\Config\ConfigurationDetector;
+use PHPUnit\Framework\TestCase;
+
+class ConfigResourceTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/phpunit-config-resource-test-'.uniqid();
+        mkdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            $files = glob($this->tempDir.'/*');
+            if (false !== $files) {
+                array_map(unlink(...), $files);
+            }
+            rmdir($this->tempDir);
+        }
+    }
+
+    public function testGetConfigurationWithExistingConfig(): void
+    {
+        $configPath = $this->tempDir.'/phpunit.xml';
+        file_put_contents($configPath, <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+XML
+        );
+
+        $originalCwd = getcwd();
+        chdir($this->tempDir);
+
+        try {
+            $detector = new ConfigurationDetector($this->tempDir);
+            $resource = new ConfigResource($detector);
+
+            $result = $resource->getConfiguration();
+
+            $this->assertIsArray($result);
+            $this->assertArrayHasKey('uri', $result);
+            $this->assertArrayHasKey('mimeType', $result);
+            $this->assertArrayHasKey('text', $result);
+
+            $this->assertSame('phpunit://config', $result['uri']);
+            $this->assertSame('text/plain', $result['mimeType']);
+            $this->assertIsString($result['text']);
+
+            // Verify the text contains expected data
+            $this->assertStringContainsString('project_root', $result['text']);
+            $this->assertStringContainsString('config_file', $result['text']);
+            $this->assertStringContainsString('config_exists', $result['text']);
+            $this->assertStringContainsString('test_directories', $result['text']);
+            $this->assertStringContainsString('bootstrap_file', $result['text']);
+            $this->assertStringContainsString('config_content', $result['text']);
+            $this->assertStringContainsString('vendor/autoload.php', $result['text']);
+        } finally {
+            if (false !== $originalCwd) {
+                chdir($originalCwd);
+            }
+        }
+    }
+
+    public function testGetConfigurationWithoutConfig(): void
+    {
+        $originalCwd = getcwd();
+        chdir($this->tempDir);
+
+        try {
+            $detector = new ConfigurationDetector($this->tempDir);
+            $resource = new ConfigResource($detector);
+
+            $result = $resource->getConfiguration();
+
+            $this->assertIsArray($result);
+            $this->assertArrayHasKey('uri', $result);
+            $this->assertArrayHasKey('mimeType', $result);
+            $this->assertArrayHasKey('text', $result);
+
+            $this->assertSame('phpunit://config', $result['uri']);
+            $this->assertSame('text/plain', $result['mimeType']);
+            $this->assertIsString($result['text']);
+
+            // Verify the text contains expected data
+            $this->assertStringContainsString('project_root', $result['text']);
+            $this->assertStringContainsString('config_file', $result['text']);
+            $this->assertStringContainsString('config_exists', $result['text']);
+        } finally {
+            if (false !== $originalCwd) {
+                chdir($originalCwd);
+            }
+        }
+    }
+
+    public function testReturnStructure(): void
+    {
+        $originalCwd = getcwd();
+        chdir($this->tempDir);
+
+        try {
+            $detector = new ConfigurationDetector($this->tempDir);
+            $resource = new ConfigResource($detector);
+
+            $result = $resource->getConfiguration();
+
+            $this->assertIsArray($result);
+            $this->assertCount(3, $result);
+            $this->assertArrayHasKey('uri', $result);
+            $this->assertArrayHasKey('mimeType', $result);
+            $this->assertArrayHasKey('text', $result);
+        } finally {
+            if (false !== $originalCwd) {
+                chdir($originalCwd);
+            }
+        }
+    }
+
+    public function testToonFormatting(): void
+    {
+        $originalCwd = getcwd();
+        chdir($this->tempDir);
+
+        try {
+            $detector = new ConfigurationDetector($this->tempDir);
+            $resource = new ConfigResource($detector);
+
+            $result = $resource->getConfiguration();
+
+            // TOON format should be compact and structured
+            $this->assertIsString($result['text']);
+            $this->assertNotEmpty($result['text']);
+
+            // TOON format produces human-readable text, not JSON
+            $this->assertStringNotContainsString('{', $result['text']);
+            $this->assertStringNotContainsString('[', $result['text']);
+        } finally {
+            if (false !== $originalCwd) {
+                chdir($originalCwd);
+            }
+        }
+    }
+
+    public function testBootstrapExtraction(): void
+    {
+        $configPath = $this->tempDir.'/phpunit.xml';
+        file_put_contents($configPath, <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+XML
+        );
+
+        $originalCwd = getcwd();
+        chdir($this->tempDir);
+
+        try {
+            $detector = new ConfigurationDetector($this->tempDir);
+            $resource = new ConfigResource($detector);
+
+            $result = $resource->getConfiguration();
+
+            $this->assertStringContainsString('tests/bootstrap.php', $result['text']);
+        } finally {
+            if (false !== $originalCwd) {
+                chdir($originalCwd);
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Issues        | N/A
| License       | MIT

### Summary

- Provide PHPUnit configuration as MCP resource
- Include project root, config file path, and test directories
- Extract bootstrap file from configuration
- Use TOON format for token-efficient output
